### PR TITLE
Remove line break from paragraph field of library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,8 +4,7 @@ license=GPL-3.0
 author=Jonathan Dempsey
 maintainer=Jonathan Dempsey <JDWifWaf@gmail.com>
 sentence=Brings new commands to the MH-Z19 series CO2 sensors via UART, while providing usage examples.
-paragraph=Current support for the ESP32 & UNO (please request additional support via GitHub).
-Features include uncapped/floored CO2, temperature at 0.06C resolution, RAW CO2, recovery sequence for dysfunctional sensors, CO2 via Analog (non-PWM) and others.
+paragraph=Current support for the ESP32 & UNO (please request additional support via GitHub). Features include uncapped/floored CO2, temperature at 0.06C resolution, RAW CO2, recovery sequence for dysfunctional sensors, CO2 via Analog (non-PWM) and others.
 category=Sensors
 url=https://github.com/WifWaf/MH-Z19B
 architectures=*


### PR DESCRIPTION
The part of the paragraph that was on a new line is interpreted by the library.properties parser as a malformed field. This caused compilation of the library to fail:
```
Error reading file (E:\arduino\libraries\MH-Z19\library.properties:7): Invalid line format, should be 'key=value'
```
This issue may block your Library Manager inclusion request (https://github.com/arduino/Arduino/issues/8451).