### PR TITLE
Provide missing span value

### DIFF
--- a/src/MHZ19.cpp
+++ b/src/MHZ19.cpp
@@ -79,7 +79,7 @@ void MHZ19::setSpan(int span)
         #endif 
     }
     else
-        provisioning(SPANCAL);
+        provisioning(SPANCAL, span);
  
     return;
 }


### PR DESCRIPTION
I think setSpan doesn't pass span value to MH-Z19B.