### PR TITLE
Change getCO2Raw return to int

### DIFF
--- a/src/MHZ19.cpp
+++ b/src/MHZ19.cpp
@@ -177,7 +177,7 @@ int MHZ19::getCO2(bool isunLimited, bool force)
     return 0;
 }
 
-float MHZ19::getCO2Raw(bool force)
+int MHZ19::getCO2Raw(bool force)
 {
     if (force == true)
         provisioning(RAWCO2);

--- a/src/MHZ19.h
+++ b/src/MHZ19.h
@@ -71,7 +71,7 @@ class MHZ19
 	int getCO2(bool isunLimited = true, bool force = true);
 
 	/* returns the "raw" CO2 value of unknown units */
-	float getCO2Raw(bool force = true);
+	int getCO2Raw(bool force = true);
 
 	/* returns Raw CO2 value as a % of transmittance */		//<--- needs work to understand
 	float getTransmittance(bool force = true);


### PR DESCRIPTION
We're getting an int from the sensor, no need to make it into a float.